### PR TITLE
Search custom fields by default

### DIFF
--- a/lib/redmine_elasticsearch/patches/search_controller_patch.rb
+++ b/lib/redmine_elasticsearch/patches/search_controller_patch.rb
@@ -112,7 +112,7 @@ module RedmineElasticsearch::Patches::SearchControllerPatch
 
     common_must = []
 
-    search_fields = options[:titles_only] ? ['title'] : %w(title description notes)
+    search_fields = options[:titles_only] ? ['title'] : %w(title description notes custom_field_values)
     search_operator = options[:all_words] ? 'AND' : 'OR'
     main_query = get_main_query(options, search_fields, search_operator)
 


### PR DESCRIPTION
Redmine searches custom fields when you do not have this plugin.  The fact that you can set which custom fields are searchable makes the search faster and more relevant.

When you add this plugin, you have to search custom fields like this: custom_field_values:keyword.  You have to be a expert of this plugin to know that fact, and even then you tend to forget to search for it with that prefix.  This pull request makes it search custom fields by default which is in line with normal Redmine.

Excellent work with this plugin!
