### PR TITLE
Query profiling/type information should only be available in dev mode

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -22,10 +22,10 @@
 
     <p><%= submit_tag l(:button_submit), :name => 'submit' %></p>
   <% end %>
-  <p>
-    query took <%= @results.time %> ms, search type: <%= @search_type %>
-  </p>
   <% if Rails.env == 'development' %>
+    <p>
+      Query took <%= @results.time %> ms, search type: <%= @search_type %>
+    </p>
     <% @query_curl.each do |query| %>
       <p><%= query %></p>
     <% end %>


### PR DESCRIPTION
The query time/type information reduces the perceived maturity of this plugin and takes up valuable screen real estate.  I suggest we only show it in development mode.
