### PR TITLE
Add _parent method in MessageSerializer

### DIFF
--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -12,6 +12,10 @@ class MessageSerializer < BaseSerializer
     object.board.try(:project_id)
   end
 
+  def _parent
+    project_id
+  end
+
   def author
     object.author.try(:name)
   end


### PR DESCRIPTION
Add `_parent` method in MessageSerializer, to set the correct value for `_parent` attribute.

Fixes searching in forums/messages.
